### PR TITLE
Use smbus2 as native smbus alternative

### DIFF
--- a/brightpi/brightpilib.py
+++ b/brightpi/brightpilib.py
@@ -10,7 +10,7 @@ __version__ = "1.0"
 # Gain from 0 to 15
 # Dim from 0 to 50
 
-import smbus
+import smbus2
 import time
 
 # Global variables to quickly reference to groups of LEDs or individual ones.
@@ -44,7 +44,7 @@ class BrightPi(object):
 
     def __init__(self):
         # Attributes are set by reading the SC620 state
-        self._bus = smbus.SMBus(1)
+        self._bus = smbus2.SMBus(1)
         self._led_on_off = self._bus.read_byte_data(BrightPi._device_address, BrightPi._led_status_register)
         self._led_dim = [0 for i in range(0, 8)]
         for i in range(0, 8):

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,7 @@ setup(name="brightpi",
       author_email='sales@pi-supply.com',
       url='pi-supply.com',
       packages=['brightpi'],
-      scripts=['src/brightpi-test.py']
-      )
+      scripts=['src/brightpi-test.py'],
+      install_requires=[
+          'smbus2>=0.2.0'
+      ])


### PR DESCRIPTION
A PR to address #7.

I've tested this only very simply against the bright-pi I just bought.  It successfully turned the `LED_IR` leds on and off.  I haven't tested the setup script against a new raspbian install, but could do that.