### PR TITLE
Fix install script for python3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ git clone https://github.com/PiSupply/Bright-Pi.git
 
 cd Bright-Pi
 
-sudo python setup.py install
+sudo python3 setup.py install
 
 whiptail --msgbox "The system will now reboot" 8 40
 sudo reboot


### PR DESCRIPTION
The install script should run the python setup using `python3` because everything else in the project is using `python3`. Without this, the project will not work as is and will probably cause confusion (as it did for me).